### PR TITLE
updated wikipdia link to "Head or tail fist"

### DIFF
--- a/src/circularfifo_memory_relaxed_aquire_release.hpp
+++ b/src/circularfifo_memory_relaxed_aquire_release.hpp
@@ -13,7 +13,7 @@
 
 // should be mentioned the thinking of what goes where
 // it is a "controversy" whether what is tail and what is head
-// http://en.wikipedia.org/wiki/FIFO#Head_or_tail_first
+// https://en.wikipedia.org/wiki/FIFO_(computing_and_electronics)#Head_or_tail_first
 
 #pragma once
 

--- a/src/circularfifo_memory_relaxed_aquire_release_padded.hpp
+++ b/src/circularfifo_memory_relaxed_aquire_release_padded.hpp
@@ -13,7 +13,7 @@
 
 // should be mentioned the thinking of what goes where
 // it is a "controversy" whether what is tail and what is head
-// http://en.wikipedia.org/wiki/FIFO#Head_or_tail_first
+// https://en.wikipedia.org/wiki/FIFO_(computing_and_electronics)#Head_or_tail_first
 
 #pragma once
 

--- a/src/circularfifo_memory_sequential_consistent.hpp
+++ b/src/circularfifo_memory_sequential_consistent.hpp
@@ -13,7 +13,7 @@
 
 // should be mentioned the thinking of what goes where
 // it is a "controversy" whether what is tail and what is head
-// http://en.wikipedia.org/wiki/FIFO#Head_or_tail_first
+// https://en.wikipedia.org/wiki/FIFO_(computing_and_electronics)#Head_or_tail_first
 
 #pragma once
 


### PR DESCRIPTION
The FIFO wikipedia page is now a disambiguation page.